### PR TITLE
fix: replace unsupported regex look-ahead in create-github-release.rs

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-03-24T08:30:32.593Z for PR creation at branch issue-3-e97604f2c293 for issue https://github.com/link-foundation/glab-pull-all/issues/3

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-24T08:30:32.593Z for PR creation at branch issue-3-e97604f2c293 for issue https://github.com/link-foundation/glab-pull-all/issues/3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "glab-pull-all"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "crossterm",

--- a/changelog.d/20260324_fix_create_github_release_regex.md
+++ b/changelog.d/20260324_fix_create_github_release_regex.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Fix `create-github-release.rs` regex panic: replace unsupported look-ahead `(?=...)` with non-capturing group `(?:...)` compatible with Rust's `regex` crate

--- a/docs/case-studies/issue-3/README.md
+++ b/docs/case-studies/issue-3/README.md
@@ -1,0 +1,84 @@
+# Case Study: Issue #3 - Fix CI/CD Pipeline
+
+## Summary
+
+The CI/CD pipeline on `main` branch was failing during the Auto Release job. The `create-github-release.rs` script panicked at runtime due to an unsupported regex feature (look-ahead) in Rust's `regex` crate.
+
+## Timeline of Events
+
+| Timestamp (UTC) | Run ID | Branch | Event | Result |
+|-----------------|--------|--------|-------|--------|
+| 2026-03-24T07:40:11Z | 23478411987 | main | push | FAILURE (`cargo package --list` - Cargo.lock uncommitted, old workflow) |
+| 2026-03-24T07:43:44Z | 23478527123 | issue-1-bbfff7e97f20 | PR | SUCCESS |
+| 2026-03-24T08:00:48Z | 23479084066 | issue-1-bbfff7e97f20 | PR | SUCCESS |
+| 2026-03-24T08:06:45Z | 23479289779 | issue-1-bbfff7e97f20 | PR | SUCCESS (merged as PR #2) |
+| 2026-03-24T08:17:53Z | 23479684794 | main | push (PR #2 merge) | **FAILURE** (regex look-ahead panic) |
+
+## Root Cause Analysis
+
+### Primary Root Cause: Unsupported Regex Look-Ahead in Rust
+
+**File:** `scripts/create-github-release.rs`, line 47
+
+**Broken pattern:**
+```rust
+let pattern = format!(r"(?s)## \[{}\].*?\n(.*?)(?=\n## \[|$)", escaped_version);
+```
+
+The `(?=\n## \[|$)` part is a **positive look-ahead assertion**. Rust's `regex` crate explicitly does not support look-ahead (or any look-around) because it guarantees linear-time matching. This caused a runtime panic:
+
+```
+thread 'main' panicked at scripts/create-github-release.rs:48:35:
+called `Result::unwrap()` on an `Err` value: Syntax(
+regex parse error:
+    (?s)## \[0\.3\.0\].*?\n(.*?)(?=\n## \[|$)
+                                 ^^^
+error: look-around, including look-ahead and look-behind, is not supported
+)
+```
+
+### Impact
+
+- The Auto Release job completed publishing to crates.io (v0.3.0 was published successfully)
+- The GitHub Release creation step failed, leaving no GitHub Release for v0.3.0
+- The release was partially completed: crates.io had the package but GitHub had no release
+
+### Secondary Issue (Run 23478411987, older commit)
+
+A separate failure on an earlier commit was caused by `cargo package --list` detecting uncommitted `Cargo.lock` changes. This was from the pre-rewrite state (package named `my-package v0.2.0`) and was resolved by the PR #2 merge that rewrote the project.
+
+## Fix Applied
+
+**Changed pattern to use non-capturing group instead of look-ahead:**
+
+```rust
+// Before (broken):
+let pattern = format!(r"(?s)## \[{}\].*?\n(.*?)(?=\n## \[|$)", escaped_version);
+
+// After (fixed):
+let pattern = format!(r"(?s)## \[{}\][^\n]*\n(.*?)(?:\n## \[|$)", escaped_version);
+```
+
+**Two changes:**
+1. `(?=\n## \[|$)` (look-ahead) replaced with `(?:\n## \[|$)` (non-capturing group) - the look-ahead was unnecessary since the `.*?` non-greedy quantifier already stops at the first match
+2. `.*?` after the version header replaced with `[^\n]*` - more precise, since the header is always a single line
+
+### Reference
+
+This fix was already applied in the reference project [`linksplatform/Numbers`](https://github.com/linksplatform/Numbers) in their `scripts/create-github-release.rs`, which uses the same CI/CD pipeline template.
+
+## Lessons Learned
+
+1. **Rust's `regex` crate does not support look-around assertions.** When porting regex patterns from other languages (JavaScript, Python, PCRE), look-ahead/look-behind must be rewritten using alternative patterns.
+
+2. **Non-greedy quantifiers (`.*?`) often make look-ahead unnecessary.** The `(?s).*?(?:\n## \[|$)` pattern naturally stops at the first occurrence of `\n## [` because `.*?` is non-greedy.
+
+3. **Partial releases are dangerous.** The pipeline published to crates.io before the GitHub Release step, meaning a script failure left the release in an inconsistent state. Consider validating all steps (including regex compilation) before starting irreversible operations like publishing.
+
+## Verification
+
+The fix was verified by:
+1. Creating a test script (`experiments/test-regex-fix.rs`) that validates the new pattern extracts changelog sections correctly
+2. Confirming the old pattern fails to compile (as expected)
+3. Running all existing tests (29 passed, 0 failed)
+4. Passing `cargo fmt` and `cargo clippy` checks

--- a/experiments/test-regex-fix.rs
+++ b/experiments/test-regex-fix.rs
@@ -1,0 +1,66 @@
+#!/usr/bin/env rust-script
+//! Test that the regex pattern in create-github-release.rs works correctly
+//! with Rust's regex crate (which does not support look-ahead).
+//!
+//! ```cargo
+//! [dependencies]
+//! regex = "1"
+//! ```
+
+use regex::Regex;
+
+fn test_changelog_extraction(version: &str, content: &str) -> Option<String> {
+    let escaped_version = regex::escape(version);
+    let pattern = format!(r"(?s)## \[{}\][^\n]*\n(.*?)(?:\n## \[|$)", escaped_version);
+    let re = Regex::new(&pattern).unwrap();
+
+    re.captures(content).map(|caps| {
+        caps.get(1).unwrap().as_str().trim().to_string()
+    })
+}
+
+fn main() {
+    let changelog = r#"# Changelog
+
+## [0.3.0] - 2026-03-24
+
+### Added
+- Full Rust implementation
+- Parallel processing
+
+## [0.2.0] - 2026-03-20
+
+### Fixed
+- Some old fix
+"#;
+
+    // Test: extract v0.3.0 section
+    let result = test_changelog_extraction("0.3.0", changelog);
+    assert!(result.is_some(), "Should find v0.3.0 section");
+    let body = result.unwrap();
+    assert!(body.contains("Full Rust implementation"), "Should contain the added items");
+    assert!(!body.contains("Some old fix"), "Should NOT contain v0.2.0 items");
+    println!("PASS: v0.3.0 extraction correct: {:?}", body);
+
+    // Test: extract v0.2.0 section (last section, ends at EOF)
+    let result = test_changelog_extraction("0.2.0", changelog);
+    assert!(result.is_some(), "Should find v0.2.0 section");
+    let body = result.unwrap();
+    assert!(body.contains("Some old fix"), "Should contain the fix items");
+    assert!(!body.contains("Full Rust implementation"), "Should NOT contain v0.3.0 items");
+    println!("PASS: v0.2.0 extraction correct: {:?}", body);
+
+    // Test: non-existent version
+    let result = test_changelog_extraction("9.9.9", changelog);
+    assert!(result.is_none(), "Should return None for missing version");
+    println!("PASS: Missing version returns None");
+
+    // Test: old broken pattern (should fail to compile)
+    let escaped = regex::escape("0.3.0");
+    let broken_pattern = format!(r"(?s)## \[{}\].*?\n(.*?)(?=\n## \[|$)", escaped);
+    let result = Regex::new(&broken_pattern);
+    assert!(result.is_err(), "Look-ahead pattern should fail to compile");
+    println!("PASS: Old broken pattern correctly fails to compile: {}", result.err().unwrap());
+
+    println!("\nAll tests passed!");
+}

--- a/scripts/create-github-release.rs
+++ b/scripts/create-github-release.rs
@@ -42,9 +42,10 @@ fn get_changelog_for_version(version: &str) -> String {
         Err(_) => return format!("Release v{}", version),
     };
 
-    // Find the section for this version
     let escaped_version = regex::escape(version);
-    let pattern = format!(r"(?s)## \[{}\].*?\n(.*?)(?=\n## \[|$)", escaped_version);
+    // Use a pattern without lookahead (not supported by the `regex` crate).
+    // Match the section header and capture everything until the next section or end of string.
+    let pattern = format!(r"(?s)## \[{}\][^\n]*\n(.*?)(?:\n## \[|$)", escaped_version);
     let re = Regex::new(&pattern).unwrap();
 
     if let Some(caps) = re.captures(&content) {


### PR DESCRIPTION
## Summary

Fixes #3

The CI/CD pipeline was failing on `main` during the Auto Release job because `scripts/create-github-release.rs` used a regex look-ahead `(?=...)` which is not supported by Rust's `regex` crate.

### Root Cause

**File:** `scripts/create-github-release.rs:47`

The regex pattern used a positive look-ahead assertion to extract changelog sections:
```rust
let pattern = format!(r"(?s)## \[{}\].*?\n(.*?)(?=\n## \[|$)", escaped_version);
```

Rust's `regex` crate guarantees linear-time matching and explicitly does not support look-around assertions, causing a runtime panic:
```
error: look-around, including look-ahead and look-behind, is not supported
```

### Fix

- Replace look-ahead `(?=\n## \[|$)` with non-capturing group `(?:\n## \[|$)` (compatible with Rust's `regex` crate)
- Replace `.*?` with `[^\n]*` for the header line match (more precise single-line match)
- Update `Cargo.lock` to match current `Cargo.toml` version (0.3.0)

This fix matches the pattern already applied in the reference project [linksplatform/Numbers](https://github.com/linksplatform/Numbers).

### Changes

- `scripts/create-github-release.rs` - Fix regex pattern
- `Cargo.lock` - Update version to 0.3.0
- `changelog.d/20260324_fix_create_github_release_regex.md` - Changelog fragment
- `docs/case-studies/issue-3/` - Case study with timeline, root cause analysis, and CI log extracts
- `experiments/test-regex-fix.rs` - Test script validating the fix

### Verification

- All 29 existing tests pass
- `cargo fmt` and `cargo clippy` pass cleanly
- Experiment script validates correct changelog extraction with the new pattern
- Confirms the old broken pattern correctly fails to compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)